### PR TITLE
[ DSD-1812 ] updated idp virtual service prefix path

### DIFF
--- a/charts/idp/values.yaml
+++ b/charts/idp/values.yaml
@@ -420,4 +420,4 @@ istio:
   enabled: true
   gateways:
     - istio-system/public
-  prefix: /v1/idp
+  prefix: /v1/idp/


### PR DESCRIPTION
IDP and IDP binding have almost the same prefix due to which IDP binding was not able access

IDP prefix: /v1/idp
IDP binding prefix: /v1/idpbinding