### PR TITLE
[MOSIP-33767] Update clusterrolebinding.yaml to add namespace in name

### DIFF
--- a/charts/artifactory/templates/clusterrolebinding.yaml
+++ b/charts/artifactory/templates/clusterrolebinding.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  name: {{ template "common.names.fullname" . }}
+  name: {{ template "common.names.fullname" . }}-{{ .Release.Namespace }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
Issue: If the chart is getting installed in multiple namespaces than ClusterRoleBinding which is shared across all the namespaces show coflict because as per chart it gets the same name artifactory and raises conflict with existing one.