### PR TITLE
Closes #1857 activemq helm chart is failing with legacy script

### DIFF
--- a/charts/activemq-artemis-2.39.0/Chart.yaml
+++ b/charts/activemq-artemis-2.39.0/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: activemq-artemis
 description: a multi-protocol, embeddable, very high performance, clustered, asynchronous messaging system.
-version: 0.0.3
+version: 0.0.4
 appVersion: 2.39.0
 dependencies:
   - name: common

--- a/charts/activemq-artemis-2.39.0/templates/slave-statefulset.yaml
+++ b/charts/activemq-artemis-2.39.0/templates/slave-statefulset.yaml
@@ -61,8 +61,6 @@ spec:
               key: artemis-password
         - name: ARTEMIS_USERNAME
           value: {{ default "artemis" .Values.artemisUser | quote }}
-        - name: ARTEMIS_USERNAME
-          value: {{ default "artemis" .Values.artemisUser | quote }}
         - name: HA_MODE
           value: "slave"
         - name: ANONYMOUS_LOGIN


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart version to reflect the latest release of the ActiveMQ Artemis deployment package.
  * Improved template formatting consistency in configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->